### PR TITLE
Enable transparency in grayscale mode

### DIFF
--- a/compton.sh
+++ b/compton.sh
@@ -7,7 +7,7 @@ uniform sampler2D tex;
 void main() {
    vec4 c = texture2D(tex, gl_TexCoord[0].xy);
    float y = dot(c.rgb, vec3(0.299, 0.587, 0.114));
-   vec4 gray = vec4(y, y, y, 1.0);
+   vec4 gray = vec4(y, y, y, c.a);
    gl_FragColor = mix(c, gray, 0.95);
 
 }


### PR DESCRIPTION
Adjusted the fragment shader to maintain the original alpha channel during grayscale conversion. This modification ensures that transparency information is retained when applying the grayscale effect. The alpha channel is now explicitly preserved in the grayscale vector, preventing unintended changes to transparency values.